### PR TITLE
Add pcap_set_immediate_mode for newer versions of libpcap

### DIFF
--- a/main.c
+++ b/main.c
@@ -246,6 +246,8 @@ int main(int argc, char * const argv[]) {
 
    // initialize pcap
    p = pcap_create(ifr.ifr_name, errbuf);
+   pcap_set_immediate_mode(p, 1);
+
    if (pcap_set_snaplen(p, 65535)) {
      pcap_perror(p, "pcap_set_snaplen");
      exit(1);


### PR DESCRIPTION
Fixes #10

In libpcap version 1.5.0 or later, pcap_set_immediate_mode should be used for packets that arrive on the interface to be processed immediately, otherwise they will be buffered.

Works with libpcap version 1.10.1-4build1.

This will break compatibility with libpcap versions older than 1.5.0.